### PR TITLE
*: pulling together from repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
 # org
+
+Centralized documents and information for the Open Containers Initiative (OCI) organization and projects.
+
+## Charter
+
+See the founding [charter][charter]
+
+## Communications
+
+### Meetings
+
+The contributors and maintainers of all OCI projects have monthly meetings, which are usually at 2:00 PM (USA Pacific) on the first Wednesday of every month.
+There is an [iCalendar][rfc5545] format for the meetings [here](meeting.ics).
+Everyone is welcome to participate via [UberConference web][uberconference] or audio-only: +1 415 968 0849 (no PIN needed).
+An initial agenda will be posted to the [mailing list](#mailing-list) in the week before each meeting, and everyone is welcome to propose additional topics or suggest other agenda alterations there.
+Minutes are posted to the [mailing list](#mailing-list) and minutes from past calls are archived [here][minutes], with minutes from especially old meetings (September 2015 and earlier) archived [here][runtime-wiki].
+
+### Mailing List
+
+You can subscribe and join the mailing list on [Google Groups][dev-list].
+
+### IRC
+
+OCI discussion happens on #opencontainers on Freenode ([logs][irc-logs]).
+
+## Technical Oversight Board (TOB)
+
+The [TOB](https://github.com/opencontainers/tob) is responsible for managing conflicts, violations of procedures or guidelines and any cross-project or high-level issues that cannot be resolved in the TDC for OCI Projects. The TOB shall also be responsible for adding, removing or reorganizing OCI Projects.
+
+## Security
+
+See [the security doc](./security.md) for reporting process and disclosure communications.
+
+## License
+
+Unless otherwise noted, code and docs of OCI projects are released under the [Apache 2.0 license](LICENSE).
+
+[charter]: https://www.opencontainers.org/about/governance
+[dev-list]: https://groups.google.com/a/opencontainers.org/forum/#!forum/dev
+[irc-logs]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/
+[rfc5545]: https://tools.ietf.org/html/rfc5545
+[minutes]: http://ircbot.wl.linuxfoundation.org/meetings/opencontainers/
+[uberconference]: https://www.uberconference.com/opencontainers
+[runtime-wiki]: https://github.com/opencontainers/runtime-spec/wiki

--- a/security.md
+++ b/security.md
@@ -1,0 +1,120 @@
+# Security
+
+## Reporting Security Issues
+
+When reporting a security issue, do not create an issue or file a pull
+request on GitHub. Instead, disclose the issue responsibly by sending an email
+to security@opencontainers.org (which is inhabited only by the maintainers of
+the various OCI projects).
+
+The maintainers take security seriously. If you discover a security issue,
+please bring it to their attention right away!
+
+## Disclosure Distribution List
+
+This list is used to provide actionable information to multiple distribution vendors at once.
+This list is not intended for individuals to find out about security issues.
+
+### Embargo Policy
+
+The information members receive on security-announce@opencontainers.org must not be made public, shared, nor even hinted at anywhere beyond the need-to-know within your specific team except with the list's explicit approval.
+This holds true until the public disclosure date/time that was agreed upon by the list.
+Members of the list and others may not use the information for anything other than getting the issue fixed for your respective distribution's users.
+
+Before any information from the list is shared with respective members of your team required to fix said issue, they must agree to the same terms and only find out information on a need-to-know basis.
+
+In the unfortunate event you share the information beyond what is allowed by this policy, you must urgently inform the security@opencontainers.org mailing list of exactly what information leaked and to whom.
+A retrospective will take place after the leak so we can assess how to not make the same mistake in the future.
+
+If you continue to leak information and break the policy outlined here, you will be removed from the list.
+
+### Contributing Back
+
+This is a team effort. As a member of the list you must carry some water. This
+could be in the form of the following:
+
+**Technical**
+
+- Review and/or test the proposed patches and point out potential issues with
+  them (such as incomplete fixes for the originally reported issues, additional
+  issues you might notice, and newly introduced bugs), and inform the list of the
+  work done even if no issues were encountered.
+
+**Administrative**
+
+- Help draft emails to the public disclosure mailing list.
+- Help with release notes.
+
+### Membership Criteria
+
+To be eligible for the security-announce@opencontainers.org mailing list, your
+distribution should:
+
+0. Have an actively monitored security email alias for our project.
+1. Have a user base not limited to your own organization.
+2. Have a publicly verifiable track record up to present day of fixing security
+   issues.
+3. Not be a downstream or rebuild of another distribution.
+4. Accept the [Embargo Policy](#embargo-policy) that is outlined above.
+5. Be willing to [contribute back](#contributing-back) as outlined above.
+6. Have someone already on the list vouch for the person requesting membership
+   on behalf of your distribution.
+
+**Removal**: If your distribution stops meeting one or more of these criteria
+after joining the list then you will be unsubscribed.
+
+### Requesting to Join
+
+New membership requests are sent to security@opencontainers.org
+
+In the body of your request please specify how you qualify and fulfill each
+criterion listed in [Membership Criteria](#membership-criteria).
+
+Here is a psuedo example:
+
+```
+To: security@opencontainers.org
+Subject: Seven-Corp Membership to security-announce@opencontainers.org
+
+Below are each criterion and why I think we, Seven-Corp, qualify.
+
+> 0. Have an actively monitored security alias email for our project.
+
+Yes, please subscribe security-response-team@example.com to the distributor's
+announce list.
+
+> 1. Have a user base not limited to your own organization.
+
+Our user base spans of the extensive "Seven" community. We have a slack and
+GitHub repos and mailing lists where the community hangs out. [links]
+
+> 2. Have a publicly verifiable track record up to present day of fixing security
+   issues.
+
+We announce on our blog all upstream patches we apply to "Seven." [link to blog
+posts]
+
+> 3. Not be a downstream or rebuild of another distribution.
+
+This does not apply, "Seven" is a unique snowflake distribution.
+
+> 4. Accept the Embargo Policy that is outlined above.
+
+We accept.
+
+> 5. Be willing to contribute back as outlined above.
+
+We are definitely willing to help!
+
+> 6. Be willing and able to handle PGP-encrypted email.
+
+Yes.
+
+> 7. Have someone already on the list vouch for the person requesting membership
+   on behalf of your distribution.
+
+CrashOverride will vouch for Acidburn joining the list on behalf of the "Seven"
+distribution.
+
+```
+


### PR DESCRIPTION
a bit from runc, runtime-spec, go-digest, as well as
https://github.com/kubernetes/sig-release/tree/8414ce5045c192fe20c6fa421c9a6f3b4866571c/security-release-process-documentation
(props to @philips on his effort there)

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>