### PR TITLE
README: weekly meetings and readibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,20 @@ See the founding [charter][charter]
 
 ### Meetings
 
-The contributors and maintainers of all OCI projects have monthly meetings, which are usually at 2:00 PM (USA Pacific) on the first Wednesday of every month.
-There are [iCalendar][rfc5545] format for the meetings [here](https://calendar.google.com/calendar/ical/linuxfoundation.org_i0sado0i37eknar51vsu8md5hg%40group.calendar.google.com/public/basic.ics) and Google Calendar [here](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_i0sado0i37eknar51vsu8md5hg%40group.calendar.google.com&ctz=America%2FLos_Angeles).
-Everyone is welcome to participate via [UberConference web][uberconference] or audio-only: +1 415 968 0849 (no PIN needed).
-An initial agenda will be posted to the [mailing list](#mailing-list) in the week before each meeting, and everyone is welcome to propose additional topics or suggest other agenda alterations there.
-Minutes are posted to the [mailing list](#mailing-list) and minutes from past calls are archived [here][minutes], with minutes from especially old meetings (September 2015 and earlier) archived [here][runtime-wiki].
+The contributors and maintainers of all OCI projects have weekly meetings.
+Everyone is welcome to participate.
+An initial agenda should be posted to the [mailing list](#mailing-list) before each meeting.
+Everyone is welcome to propose additional topics or suggest other agenda alterations there.
+
+* Time: [2200 UTC](http://www.timebie.com/std/utc.php?q=22)
+* Location: [UberConference web][uberconference] or audio-only: +1 415 968 0849 (no PIN needed)
+* Meeting notes: #opencontainers on freenode (or [#general on opencontainers.slack.com](https://opencontainers.slack.com/messages/C0KDPQ3L6/)
+* Historical Minutes: [ircbot minutes][minutes]
+* [iCalendar][rfc5545]: [link](https://calendar.google.com/calendar/ical/linuxfoundation.org_i0sado0i37eknar51vsu8md5hg%40group.calendar.google.com/public/basic.ics)
+* Google Calendar: [link](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_i0sado0i37eknar51vsu8md5hg%40group.calendar.google.com&ctz=America%2FLos_Angeles)
+
+_([ancient minutes][runtime-wiki] from 2015 and earlier)_
+
 
 ### Mailing List
 


### PR DESCRIPTION
We're moving to weekly (from bi-weekly) meetings, so the monthly info is
already incorrect.

A big paragraph is not suitable for readibility. Make a bullet list.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>