### PR TITLE
adding meeting notes for 3-6-2019

### DIFF
--- a/meeting-notes/notes-3-6-2019.md
+++ b/meeting-notes/notes-3-6-2019.md
@@ -1,0 +1,52 @@
+# Meeting Notes
+March 6, 2019
+
+## Attendees:
+  - Vincent Batts
+  - Phil Estes
+  - Mike Brown
+  - Vanessa Sochat
+  - Eric Ernst
+  - Atlas Kerr
+  - Chris Hoge
+  - Gilbert Song
+  - Steve Lasker
+  - Derek McGowan
+  - Jimmy Zelinske
+  - Eric Hotinger
+  - Samuel Karp (I think; from Amazon)
+  - Tianon
+
+## Agenda items: 
+  - [distribution-spec v1](https://github.com/opencontainers/distribution-spec/milestone/3)
+  - [cgroup v2](https://github.com/opencontainers/runtime-spec/issues/1002)
+  - Cleanup (heads up maintainers):
+    - https://github.com/opencontainers/org/issues/3
+    - https://github.com/opencontainers/runtime-spec/pull/1001
+    - https://github.com/opencontainers/runc/pull/2002
+    - https://github.com/opencontainers/org/pulls
+
+## Contribution Workflow
+
+Discussed briefly adding a folder for proposals and meetings notes to the org repo, [issue created](https://github.com/opencontainers/org/issues/12)
+and more discussion next week. 
+ - [Original PR](https://github.com/opencontainers/org/pull/6) to add contributing docs to the org repo, and 
+ - [Just adding Contributing Docs](https://github.com/opencontainers/org/pull/9) is the consolidated version to break apart the pull requests. 
+ - [Web Preview](https://vsoch.github.io/org/) is the web preview for the pull request PR (I'll keep it updated with the add/contributing-docs PR)
+
+## Cgroup v2
+
+Mostly a heads up regarding more imminent arrival of cgroup v2 in distributions. Ubuntu latest releases already providing unified mount. Fedora (2? : vbatts?) potentially switching with boot flag.
+
+## Distribution-spec
+
+Discussion covering the open issues against the [v1.0.0-rc1 milestone in GitHub](https://github.com/opencontainers/distribution-spec/milestone/3). 
+
+Specific discussion on removing references to Docker v2 schema 1 manifests (issue [#47](https://github.com/opencontainers/distribution-spec/issues/47)) and vendor-specific HTTP headers (issue [#26](https://github.com/opencontainers/distribution-spec/issues/26)).
+
+Vincent added issue [#39](https://github.com/opencontainers/distribution-spec/pull/39) to the milestone: Dongsu's ocicert tests.
+
+We need a proposal for the way forward on https://github.com/opencontainers/distribution-spec/issues/22
+JimmiZ says that `_catalog` and search are tied together.
+The clair model is registering with a registry, so new pushes to the registry trigger a webhook to call the scan.
+SteveLas - correlating the listing and eventing together would be a good scenario to cover. Possibly cover the requirements of a catalog/listing API. Mike suggested starting this now, and seeing if we can land it before 1.0 ships.

--- a/meeting-notes/notes-3-6-2019.md
+++ b/meeting-notes/notes-3-6-2019.md
@@ -50,3 +50,42 @@ We need a proposal for the way forward on https://github.com/opencontainers/dist
 JimmiZ says that `_catalog` and search are tied together.
 The clair model is registering with a registry, so new pushes to the registry trigger a webhook to call the scan.
 SteveLas - correlating the listing and eventing together would be a good scenario to cover. Possibly cover the requirements of a catalog/listing API. Mike suggested starting this now, and seeing if we can land it before 1.0 ships.
+
+## Call notes (from IRC)
+
+> 17:00:53          estesp | #startmeeting OCI Weekly Dev Call
+> 17:00:53        collabot | Meeting started Wed Mar  6 22:00:53 2019 UTC.  The chair is estesp. Information about MeetBot at http://wiki.debian.org/MeetBot.
+> 17:00:53        collabot | Useful Commands: #action #agreed #help #info #idea #link #topic.
+> 17:00:53        collabot | The meeting name has been set to 'oci_weekly_dev_call'
+> 17:07:53          estesp | #topic potentially have a better shared mechanism to collaborate on agenda + actions/notes
+> 17:09:31          estesp | atlas: potential to use org repo to store content/weekly discussion
+> 17:10:55          estesp | vanessa: shared doc during call lets people follow and focus
+> 17:12:12          estesp | atlas: obvious pros/cons to various methods
+> 17:13:19          estesp | vbatts: inline commenting in shared doc during call is good; but can be transcribed to markdown as summary for later (did I get that
+>                          | right?)
+> 17:13:59          estesp | atlas: try Google Docs next week (vanessa: or this week!)
+> 17:15:31          estesp | lasker: how about hackmd.io? like shared Google docs, but saves in markdown
+> 17:16:27          estesp | #link https://hackmd.io/El8Dd2xrTlCaCG59ns5cwg
+> 17:18:37          estesp | #topic cgroup v2  
+> 17:19:02          estesp | #link https://github.com/opencontainers/runtime-spec/issues/1002
+> 17:19:59          estesp | vbatts: looking more imminent; Ubuntu already has unified mount; Fedora 2? possibly switching
+> 17:24:48          estesp | #topic distribution spec v1
+> 17:25:48          estesp | atlas: removing references to docker v2 schema 1 is mostly done
+> 17:26:15          estesp | #link https://github.com/opencontainers/distribution-spec/milestone/3
+> 17:26:52          estesp | atlas: vbatts: discussing vendor specific strings in headers
+> 17:26:59          estesp | #link https://github.com/opencontainers/distribution-spec/issues/26
+> 17:35:57          estesp | vbatts adding issue #39 to the milestone
+> 17:36:01          estesp | #link https://github.com/opencontainers/distribution-spec/pull/39
+> 17:37:43          estesp | #topic moving common content to the org project
+> 17:38:01          estesp | vbatts: code of conduct and security disclosure are already moved thanks to Vanessa
+> 17:38:46          estesp | #link https://github.com/opencontainers/org
+> 17:40:43          estesp | vanessa: discussing the intro content PR and deploying it to a github pages site
+> 17:46:23          estesp | #topic catalog/listing capabilities of registries
+> 17:49:25          estesp | lasker, vbatts, atlas discussing potential for a proposal in this area
+> 17:49:43          estesp | vbatts: need a proposal for a way forward on issue #22
+> 17:49:48          estesp | #link https://github.com/opencontainers/distribution-spec/issues/22
+> 17:59:31          estesp | #endmeeting
+> 17:59:31        collabot | Meeting ended Wed Mar  6 22:59:31 2019 UTC.  Information about MeetBot at http://wiki.debian.org/MeetBot . (v 0.1.4)
+> 17:59:31        collabot | Minutes:        http://ircbot.wl.linuxfoundation.org/meetings/opencontainers/2019/opencontainers.2019-03-06-22.00.html
+> 17:59:31        collabot | Minutes (text): http://ircbot.wl.linuxfoundation.org/meetings/opencontainers/2019/opencontainers.2019-03-06-22.00.txt
+> 17:59:31        collabot | Log:            http://ircbot.wl.linuxfoundation.org/meetings/opencontainers/2019/opencontainers.2019-03-06-22.00.log.html


### PR DESCRIPTION
Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>

Here is a test to add meeting notes (via a folder with markdowns) from our calls to the repository. These are from [here](https://hackmd.io/El8Dd2xrTlCaCG59ns5cwg)