### PR TITLE
add copyright and license notice

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,13 @@
+   Copyright The Linux Foundation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
Should probably include a NOTICE file as recommended by the apache software foundation here:

http://www.apache.org/licenses/LICENSE-2.0#apply

Note: I left the year off so we don't have to change it each year to include additional year ranges.

example of another project providing notice in this fashion:

https://github.com/grpc/grpc/blob/master/NOTICE.txt

if we ever add 3rd party copyrighted code and/or that has a difference license, the notice file should be updated to include that information.... 

Signed-off-by: Mike Brown <brownwm@us.ibm.com>